### PR TITLE
Add resolve when cached sObject not found

### DIFF
--- a/src/getCachedSobj.js
+++ b/src/getCachedSobj.js
@@ -43,6 +43,8 @@ module.exports = (opts) => {
         resolve(opts);
         return;
       }
+ 
+      resolve(opts);
 
 /*
       storage.getItem(id, (item)=>{


### PR DESCRIPTION
Prevent getCachedSobj trapped when there is no cached value